### PR TITLE
Update PKGBUILD-32 to Wine 5.5

### DIFF
--- a/PKGBUILD-32
+++ b/PKGBUILD-32
@@ -2,9 +2,9 @@
 
 pkgname=lib32-wine-wayland
 _pkgname=wine-wayland
-pkgver=5.1
+pkgver=5.5
 pkgrel=81
-_winesrcdir='wine-wine-5.1'
+_winesrcdir='wine-wine-5.5'
 _esyncsrcdir='esync'
 _where=$PWD
 
@@ -45,7 +45,7 @@ makedepends=(
 )
 
 
-source=("https://github.com/wine-mirror/wine/archive/wine-5.1.zip")
+source=("https://github.com/wine-mirror/wine/archive/wine-$pkgver.zip")
     
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Otherwise, 32-bit PKGBUILD (with --noextract, as recommended in README) fails to call `wine-wine-5.1/configure`, as (previously called) 64-bit PKGBUILD extracts Wine sources to directory `wine-wine-5.5` since last commit 3fa15d3.