### PR TITLE
add cmake as build dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,6 +39,7 @@ depends=(
 
 makedepends=(
   'autoconf'
+  'cmake'
   'ncurses'
   'bison'
   'perl'


### PR DESCRIPTION
Hello! From trying to build these packages on my system, I noticed that it failed until I installed `cmake`. Just in case someone else doesn't have it installed like me, I figured it should probably be added to the list of build dependencies.